### PR TITLE
 Run fix-permissions on ${ivy_dir} after build

### DIFF
--- a/2.11.8/s2i/bin/assemble
+++ b/2.11.8/s2i/bin/assemble
@@ -141,4 +141,6 @@ check_project_sbt ${S2I_SOURCE_DIR}
 apply_plugins ${S2I_SOURCE_DIR} ${sbt_dir}
 build_sbt ${S2I_SOURCE_DIR} ${DEPLOYMENTS_DIR}
 
+echo "Run fix-permissions on ${ivy_dir}"
+fix-permissions ${ivy_dir}
 echo "... done"


### PR DESCRIPTION
This sets standard s2i group permissions on dependency files
downloaded as part of the build.